### PR TITLE
Add unauthorized access tests for protected pages redirecting to login

### DIFF
--- a/storage-monitor-automation/src/test/java/automation/test/UnAuthenticatedPathTest.java
+++ b/storage-monitor-automation/src/test/java/automation/test/UnAuthenticatedPathTest.java
@@ -1,0 +1,24 @@
+package automation.test;
+
+import automation.base.BaseTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvFileSource;
+import org.openqa.selenium.WebDriver;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class UnAuthenticatedPathTest extends BaseTest {
+    @ParameterizedTest()
+    @CsvFileSource(resources = "/path-access.csv", numLinesToSkip = 1)
+    public void testUnAuthenticatedPath(String path, Boolean shouldRedirect) {
+        setUp(path);
+        String current = wait.until(WebDriver::getCurrentUrl);
+        if (shouldRedirect) {
+            assertTrue(current.contains("/login"));
+        } else {
+            assertTrue(current.endsWith("/" + path));
+        }
+
+        tearDown();
+    }
+}

--- a/storage-monitor-automation/src/test/resources/path-access.csv
+++ b/storage-monitor-automation/src/test/resources/path-access.csv
@@ -1,0 +1,7 @@
+path,shouldRedirect
+home,true
+storagelist,true
+products,true
+production,true
+login,false
+register,false


### PR DESCRIPTION
- Introduced a new parameterized test class UnAuthenticatedPathTest that verifies unauthenticated and unauthorized users are redirected to /login when trying accessing protected routes such as: /home, /storagelist, /products, /production.

- ath-access.csv was added to the project containing paths and the shouldRedirect Boolean value.

- The tests are testing the resulting URL.